### PR TITLE
[TOOLCM-4360] Enable dual publish to CodeArtifact and Nexus

### DIFF
--- a/mcp-bom/pom.xml
+++ b/mcp-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
         <artifactId>mcp-parent</artifactId>
-        <version>0.12.0-sprout</version>
+        <version>0.13.0-sprout</version>
     </parent>
 
     <artifactId>mcp-bom</artifactId>
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
                 <artifactId>mcp</artifactId>
-                <version>0.12.0-sprout</version>
+                <version>0.13.0-sprout</version>
             </dependency>
 
             <!-- MCP Test -->

--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mcp-spring-webflux</artifactId>
@@ -25,13 +25,13 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-test</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mcp-spring-webmvc</artifactId>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 		</dependency>
 
 		<dependency>
@@ -37,14 +37,14 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-test</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 
 				<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mcp-test/pom.xml
+++ b/mcp-test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 	</parent>
 	<artifactId>mcp-test</artifactId>
 	<packaging>jar</packaging>
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 		</dependency>
 
 		<dependency>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 	</parent>
 	<artifactId>mcp</artifactId>
 	<packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 	<artifactId>mcp-parent</artifactId>
-	<version>0.12.0-sprout</version>
+	<version>0.13.0-sprout</version>
 
 	<packaging>pom</packaging>
 	<url>https://github.com/modelcontextprotocol/java-sdk</url>
@@ -255,10 +255,23 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Deploy to US CodeArtifact -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>${maven-deploy-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>us-deploy</id>
+						<phase>deploy</phase>
+						<goals>
+							<goal>deploy</goal>
+						</goals>
+						<configuration>
+							<altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
             <plugin>
                 <groupId>com.github.eirslett</groupId>
@@ -387,6 +400,16 @@
 			<releases>
 				<enabled>true</enabled>
 			</releases>
+		</repository>
+		<repository>
+			<id>sproutsocial-us-releases</id>
+			<url>https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Enables dual publishing to AWS CodeArtifact on `java-mcp-sdk` while preserving the existing Nexus deployment. This is part of the Phase 1 Nexus → CodeArtifact migration (TOOLCM-4349). Artifacts will now be published to both registries during `mvn deploy`, allowing gradual consumer migration without disruption.

## Change Summary

- **pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (minor). Added a `us-deploy` execution to the existing `maven-deploy-plugin` declaration with an `altDeploymentRepository` pointing at the `sproutsocial-us-releases` CodeArtifact registry. Added a matching `<repository>` entry for `sproutsocial-us-releases` under `<repositories>` so the registry is also available for dependency resolution. Existing Nexus `<distributionManagement>` is untouched.
- **mcp-bom/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref + internal module refs).
- **mcp/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref).
- **mcp-test/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref + internal `mcp` dep).
- **mcp-spring/mcp-spring-webflux/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref + internal module refs).
- **mcp-spring/mcp-spring-webmvc/pom.xml**: Version bumped 0.12.0-sprout → 0.13.0-sprout (parent ref + internal module refs).

No CHANGELOG.md exists in this repo, so none was added (per the skill: don't introduce new CHANGELOGs).

## Related Links

- [TOOLCM-4360](https://sprout.atlassian.net/browse/TOOLCM-4360)
- [TOOLCM-4349](https://sprout.atlassian.net/browse/TOOLCM-4349) (parent batch)

[TOOLCM-4360]: https://sprout.atlassian.net/browse/TOOLCM-4360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ