### PR TITLE
[TOOLCM-3834] Enable dual publish to CodeArtifact and Nexus

### DIFF
--- a/mcp-bom/pom.xml
+++ b/mcp-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
         <artifactId>mcp-parent</artifactId>
-        <version>0.12.0-sprout</version>
+        <version>0.13.0-sprout</version>
     </parent>
 
     <artifactId>mcp-bom</artifactId>
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
                 <artifactId>mcp</artifactId>
-                <version>0.12.0-sprout</version>
+                <version>0.13.0-sprout</version>
             </dependency>
 
             <!-- MCP Test -->

--- a/mcp-spring/mcp-spring-webflux/pom.xml
+++ b/mcp-spring/mcp-spring-webflux/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mcp-spring-webflux</artifactId>
@@ -25,13 +25,13 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-test</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mcp-spring/mcp-spring-webmvc/pom.xml
+++ b/mcp-spring/mcp-spring-webmvc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>mcp-spring-webmvc</artifactId>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 		</dependency>
 
 		<dependency>
@@ -37,14 +37,14 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-test</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 
 				<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp-spring-webflux</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/mcp-test/pom.xml
+++ b/mcp-test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 	</parent>
 	<artifactId>mcp-test</artifactId>
 	<packaging>jar</packaging>
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 			<artifactId>mcp</artifactId>
-			<version>0.12.0-sprout</version>
+			<version>0.13.0-sprout</version>
 		</dependency>
 
 		<dependency>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 		<artifactId>mcp-parent</artifactId>
-		<version>0.12.0-sprout</version>
+		<version>0.13.0-sprout</version>
 	</parent>
 	<artifactId>mcp</artifactId>
 	<packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.sproutsocial.io.modelcontextprotocol.sdk</groupId>
 	<artifactId>mcp-parent</artifactId>
-	<version>0.12.0-sprout</version>
+	<version>0.13.0-sprout</version>
 
 	<packaging>pom</packaging>
 	<url>https://github.com/modelcontextprotocol/java-sdk</url>
@@ -255,10 +255,23 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Deploy to US CodeArtifact -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>${maven-deploy-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>us-deploy</id>
+						<phase>deploy</phase>
+						<goals>
+							<goal>deploy</goal>
+						</goals>
+						<configuration>
+							<altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
             <plugin>
                 <groupId>com.github.eirslett</groupId>
@@ -387,6 +400,16 @@
 			<releases>
 				<enabled>true</enabled>
 			</releases>
+		</repository>
+		<repository>
+			<id>sproutsocial-us-releases</id>
+			<url>https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Enables dual publishing of Maven artifacts to AWS CodeArtifact while preserving the existing Nexus deployment, as part of the Nexus -> CodeArtifact migration.

## Changes
- Add a `us-deploy` execution to the root pom's `maven-deploy-plugin`, deploying to the `sproutsocial-us-releases` CodeArtifact repository via `altDeploymentRepository`.
- Add the `sproutsocial-us-releases` CodeArtifact repository to `<repositories>`.
- Bump version `0.12.0-sprout` -> `0.13.0-sprout` across all modules (parent + child `<parent>`/dependency references).
- Existing Nexus `<distributionManagement>` is preserved unchanged, so both destinations receive artifacts.

Plugin/repository config lives only in the root pom; child modules only receive the version bump.

Jira: https://sprout.atlassian.net/browse/TOOLCM-3834

🤖 Generated with [Claude Code](https://claude.com/claude-code)